### PR TITLE
Adding function to build an index file for the export.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
             "type": "python",
             "request": "launch",
             "program": "${workspaceFolder}/confluenceDumpWithPython.py",
-            "args": "--site qpssoftware --mode space --space HLPqiEN --html --no-rst --confluence",
+            "args": "--site optile --mode pageprops --page 78872647",
 //            "console": "integratedTerminal",
             "justMyCode": true,
 //            "preLaunchTask": "source .venv/bin/activate"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
             "type": "python",
             "request": "launch",
             "program": "${workspaceFolder}/confluenceDumpWithPython.py",
-            "args": "--site optile --mode pageprops --page 78872647",
+            "args": "--site qpssoftware --mode space --space HLPqiEN --html --no-rst --confluence",
 //            "console": "integratedTerminal",
             "justMyCode": true,
 //            "preLaunchTask": "source .venv/bin/activate"

--- a/confluenceDumpWithPython.py
+++ b/confluenceDumpWithPython.py
@@ -279,6 +279,10 @@ elif args.mode == 'space':
                 'space_id' : n['spaceId'],
                 }
             )
+
+        # Make an index.html file
+        myModules.dump_index_file(all_pages_full, my_outdir_content, space_key, sphinx_compatible, confluence_compatible)
+
         # put it all together
         logging.debug(f"{len(all_pages_short)} pages to export")
         page_counter = 0

--- a/confluenceDumpWithPython.py
+++ b/confluenceDumpWithPython.py
@@ -281,7 +281,8 @@ elif args.mode == 'space':
             )
 
         # Make an index.html file
-        myModules.dump_index_file(all_pages_full, my_outdir_content, space_key, sphinx_compatible, confluence_compatible)
+        if args.html == True:
+            myModules.dump_index_file(all_pages_full, my_outdir_content, space_key, sphinx_compatible, confluence_compatible)
 
         # put it all together
         logging.debug(f"{len(all_pages_short)} pages to export")

--- a/myModules.py
+++ b/myModules.py
@@ -628,7 +628,7 @@ def dump_index_file(
 
     index_list = f""
     for page in arg_pages:
-        if page['parentId'] == None:        
+        if page['parentId'] is None:        
             index_list += append_child_pages_to_index_file(page, arg_pages, arg_confluence_compatible)
 
     html_file_path = os.path.join(my_outdir_content,"index.html")

--- a/myModules.py
+++ b/myModules.py
@@ -685,7 +685,7 @@ def append_child_pages_to_index_file(
     # recursively write the child pages to this list.
     for page in arg_pages:
         if page['parentId'] == arg_page['id']:            
-            result += append_child_pages(page, arg_pages, arg_confluence_compatible)
+            result += append_child_pages_to_index_file(page, arg_pages, arg_confluence_compatible)
 
     # close the list item and unordered list.            
     result += (f"</li>\n"


### PR DESCRIPTION
(Maybe the changes in the launch.json shouldn't be merged.)

Please review my code changes. Added a function to the export space, to create an index.html file.

A snippet of the result looks like this (after formatting):
```
<html>

<head>
    <title>Key</title>
    <link rel="stylesheet" href="_static/confluence.css" type="text/css" />
    <meta name="generator" content="confluenceExportHTML" />
    <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
</head>
<ul>
    <li>
        <a href=Help.html>Help</a>
        <ul>
            <li>
                <a href=Help_42076768.html>Help</a>
                <ul>
                    <li>
                        <a href=Item1_42074376.html>Item1</a>
                        <ul>
                            <li>
                                <a href=Item2-View_42074212.html>Item2 View</a>
                            </li>
                        </ul>
                        <ul>
                            <li>
                                <a href=Item3-Settings_42074225.html>Item3 Settings</a>
                                <ul>
                                    <li>
                                        <a href=Item4_42078067.html>Item4</a>
                                    </li>
                                </ul>
                            </li>
                        </ul>
                    </li>
                </ul>
                <ul>
```